### PR TITLE
Fix: job final action buttons replaced by the progress message

### DIFF
--- a/dev_gui/src/modules/job-monitor.js
+++ b/dev_gui/src/modules/job-monitor.js
@@ -35,6 +35,14 @@ export function jobMonitor(item, options = {}) {
     responsediv.id = 'responsediv';
     item.prepend(responsediv);
   }
+  // the progress message has its own node, otherwise writing it would wipe out
+  // the final action (download, ... ) inserted in responsediv when job is done
+  let messagediv = document.getElementById("responsemessage");
+  if (messagediv === null) {
+    messagediv = document.createElement('div');
+    messagediv.id = 'responsemessage';
+    responsediv.append(messagediv);
+  }
 
 
   let stop = false;
@@ -42,7 +50,7 @@ export function jobMonitor(item, options = {}) {
   const progress_bar = function(state, percent = 0, msg = "") {
     if (!percent) percent = 0;
     const progressbar = document.getElementById('progressbar');
-    responsediv.textContent = msg;
+    messagediv.textContent = msg;
     if (divstate) divstate.textContent = msg;
     if (progressbar !== null) {
       progressbar.firstChild.textContent = percent + '%';
@@ -153,11 +161,26 @@ export function jobMonitor(item, options = {}) {
     });
   }
   let html = [];
+  let final_displayed = false;
+
+  function display_final() {
+    if (!responsediv) return;
+    if (html.length && !final_displayed) {
+      final_displayed = true;
+      responsediv.insertAdjacentHTML('afterbegin', html.join(''));
+      // bind the actions (get file, ... ) of the inserted buttons, as done on a page load
+      import('../modules/activ-items.js').then(({
+        ActivItems
+      }) => ActivItems.applyTo(responsediv));
+    }
+    responsediv.classList.remove(css.hide);
+  }
 
   function check_job_status() {
     if (_fetching) return;
     _fetching=true;
     fetch(options.url + jobid, fetchSettings).then(response => response.json()).then(job => {
+      let showfinal = false;
        if (job) {
         switch (job.state) {
           case "A":
@@ -181,16 +204,12 @@ export function jobMonitor(item, options = {}) {
             break;
         }
 
-        if (job.state && job.state === "E" || job.state === 'F' || job.type === "Prediction") {
-          //  display_final(job.finalaction);
-          if (responsediv) {
-            responsediv.insertAdjacentHTML('afterbegin', html.join(''));
-            responsediv.classList.remove(css.hide);
-          }
-          stop = true;
-        }
+        showfinal = (job.state === "E" || job.state === 'F' || job.type === "Prediction");
+        if (showfinal) stop = true;
       } else stop = true;
       if (job.state) display_infos(job);
+      // after display_infos, which refreshes the progress message
+      if (showfinal) display_final();
       if (stop === false) setTimeout(check_job_status, 1000);
       return;
     }).catch((err) => {


### PR DESCRIPTION
## Problem

When an export job finished while its monitoring page (`/gui/job/show/<id>`) was open, the download / cleanup buttons never showed up: the area displayed `Done` instead, and a page reload was needed to get the buttons.

Sequence in `dev_gui/src/modules/job-monitor.js`:

1. on state `F`, the final action HTML (`job.finalaction`, i.e. the *Get file* and *FORCE Delete* buttons) is inserted in `#responsediv`;
2. right after, `display_infos(job)` → `progress_bar()` does `responsediv.textContent = msg`, which **wipes the buttons**;
3. the back-end sets `progress_msg = "Done"` when a job completes (`JobService.set_job_result`), hence the `Done` text in place of the buttons.

## Changes

- the progress message is written in its own node (`#responsemessage`) so it no longer overwrites the content of `#responsediv`;
- the final action is inserted *after* `display_infos()`, and only once — it used to be re-inserted on every poll for `Prediction` jobs;
- `ActivItems.applyTo()` is run on the inserted HTML, so the `data-action` of the buttons (`getfile`, …) are bound as they are on a page load. Without this the buttons showed up but missed part of their behaviour.

State `A` (question) still goes through `display_infos()`, as it did before.

## Note

The GUI is served from the compiled bundle (`appli/static/gui/dist/`), so this needs a `npm run build` in `dev_gui/` to be effective. Not included in this PR to keep the diff reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
